### PR TITLE
Add touch / position to logging

### DIFF
--- a/Assets/Scenes/Common/Scripts/DataCaptureSystem.cs
+++ b/Assets/Scenes/Common/Scripts/DataCaptureSystem.cs
@@ -118,9 +118,15 @@ public class DataCaptureSystem : MonoBehaviour
             "deceleration",
             "jump",
             "occlusion",
-            "Click.position",
-            "Train.transform.position",
-            "Train.transform.eulerAngles",
+            "Click.x",
+            "Click.y",
+            "Click.z",
+            "Train.transform.position.x",
+            "Train.transform.position.y",
+            "Train.transform.position.z",
+            "Train.transform.eulerAngles.x",
+            "Train.transform.eulerAngles.y",
+            "Train.transform.eulerAngles.z",
             "Train.IsHeld"
         };
         tsv.Add(string.Join(separator, eventsOfInterest));

--- a/Assets/Scenes/Common/Scripts/DataCaptureSystem.cs
+++ b/Assets/Scenes/Common/Scripts/DataCaptureSystem.cs
@@ -111,7 +111,6 @@ public class DataCaptureSystem : MonoBehaviour
     public void ExportAnalysisEvents(string filepath, string separator = "\t")
     {
         List<string> tsv = new List<string>();
-
         List<string> eventsOfInterest = new List<string>
         {
             "frame",
@@ -119,6 +118,9 @@ public class DataCaptureSystem : MonoBehaviour
             "deceleration",
             "jump",
             "occlusion",
+            "Click.position",
+            "Train.transform.position",
+            "Train.transform.eulerAngles",
             "Train.IsHeld"
         };
         tsv.Add(string.Join(separator, eventsOfInterest));
@@ -129,7 +131,7 @@ public class DataCaptureSystem : MonoBehaviour
             .Select(group => group.ToList())
             .ToList();
 
-        // Convert groups to tsv lines
+        // Convert frame number groups to tsv lines
         foreach (List<string> group in eventsByFrame)
         {
             List<string> csvLine = new List<string>();
@@ -152,28 +154,11 @@ public class DataCaptureSystem : MonoBehaviour
                 }
             }
 
-            bool hasEvent = false;
             foreach (string eventName in eventsOfInterest)
             {
-                if (eventName == "frame")
-                {
-                    continue;
-                }
-                if (currentFrame[eventName] != "FALSE")
-                {
-                    hasEvent = true;
-                    break;
-                }
+                csvLine.Add(currentFrame[eventName]);
             }
-
-            if (hasEvent)
-            {
-                foreach (string eventName in eventsOfInterest)
-                {
-                    csvLine.Add(currentFrame[eventName]);
-                }
-                tsv.Add(string.Join(separator, csvLine));
-            }
+            tsv.Add(string.Join(separator, csvLine));
         }
         System.IO.File.WriteAllLines(filepath, tsv.ToArray());
     }

--- a/Assets/Scenes/Common/Scripts/GlobalManager.cs
+++ b/Assets/Scenes/Common/Scripts/GlobalManager.cs
@@ -27,4 +27,14 @@ public class GlobalManager : MonoBehaviour
             DontDestroyOnLoad(gameObject);
         }
     }
+
+    void Update()
+    {
+        if (Input.GetMouseButton(0) || Input.touchCount > 0)
+        {
+            Vector2 ClickPosition =
+                Input.touchCount > 0 ? Input.GetTouch(0).position : (Vector2)Input.mousePosition;
+            DataCaptureSystem.Instance.ReportEvent("Click.position", ClickPosition);
+        }
+    }
 }

--- a/Assets/Scenes/Common/Scripts/GlobalManager.cs
+++ b/Assets/Scenes/Common/Scripts/GlobalManager.cs
@@ -27,14 +27,4 @@ public class GlobalManager : MonoBehaviour
             DontDestroyOnLoad(gameObject);
         }
     }
-
-    void Update()
-    {
-        if (Input.GetMouseButton(0) || Input.touchCount > 0)
-        {
-            Vector2 ClickPosition =
-                Input.touchCount > 0 ? Input.GetTouch(0).position : (Vector2)Input.mousePosition;
-            DataCaptureSystem.Instance.ReportEvent("Click.position", ClickPosition);
-        }
-    }
 }

--- a/Assets/Scenes/TrainTaskV1/Scripts/Movable.cs
+++ b/Assets/Scenes/TrainTaskV1/Scripts/Movable.cs
@@ -4,14 +4,11 @@ using UnityEngine;
 
 /// <summary>
 /// This class represents a movable object in the scene. It provides
-/// functionality for detecting changes in position, rotation, and scale,
+/// functionality for detecting changes in position, and rotation,
 /// and reporting those changes to a data capture system.
 /// </summary>
 public class Movable : MonoBehaviour
 {
-    private Vector3 lastPosition;
-    private Vector3 lastRotation;
-
     /// <summary>
     /// Initializes the last position, and rotation values to the current transform values.
     /// </summary>
@@ -27,17 +24,14 @@ public class Movable : MonoBehaviour
     /// </summary>
     public void Update()
     {
-        if (lastPosition != transform.position || lastRotation != transform.eulerAngles)
-        {
-            DataCaptureSystem.Instance.ReportEvent(
-                $"{this.name}.transform.position",
-                transform.position
-            );
-            DataCaptureSystem.Instance.ReportEvent(
-                $"{this.name}.transform.eulerAngles",
-                transform.eulerAngles
-            );
-        }
+        DataCaptureSystem.Instance.ReportEvent(
+            $"{this.name}.transform.position",
+            transform.position
+        );
+        DataCaptureSystem.Instance.ReportEvent(
+            $"{this.name}.transform.eulerAngles",
+            transform.eulerAngles
+        );
         lastPosition = transform.position;
         lastRotation = transform.eulerAngles;
     }

--- a/Assets/Scenes/TrainTaskV1/Scripts/Movable.cs
+++ b/Assets/Scenes/TrainTaskV1/Scripts/Movable.cs
@@ -10,29 +10,36 @@ using UnityEngine;
 public class Movable : MonoBehaviour
 {
     /// <summary>
-    /// Initializes the last position, and rotation values to the current transform values.
-    /// </summary>
-    void Start()
-    {
-        lastPosition = transform.position;
-        lastRotation = transform.eulerAngles;
-    }
-
-    /// <summary>
     /// This method is called every frame and checks if the position, rotation, or scale of the object has changed since the last frame.
     /// If any of these values have changed, it reports the changes to the data capture system.
     /// </summary>
     public void Update()
     {
+        // The following could be looped, but it is written out for clarity.
+        // Reflection does not provide nice-looking code.
         DataCaptureSystem.Instance.ReportEvent(
-            $"{this.name}.transform.position",
-            transform.position
+            $"{this.name}.transform.position.x",
+            this.transform.position.x
         );
         DataCaptureSystem.Instance.ReportEvent(
-            $"{this.name}.transform.eulerAngles",
-            transform.eulerAngles
+            $"{this.name}.transform.position.y",
+            this.transform.position.y
         );
-        lastPosition = transform.position;
-        lastRotation = transform.eulerAngles;
+        DataCaptureSystem.Instance.ReportEvent(
+            $"{this.name}.transform.position.z",
+            this.transform.position.z
+        );
+        DataCaptureSystem.Instance.ReportEvent(
+            $"{this.name}.transform.eulerAngles.x",
+            this.transform.eulerAngles.x
+        );
+        DataCaptureSystem.Instance.ReportEvent(
+            $"{this.name}.transform.eulerAngles.y",
+            this.transform.eulerAngles.y
+        );
+        DataCaptureSystem.Instance.ReportEvent(
+            $"{this.name}.transform.eulerAngles.z",
+            this.transform.eulerAngles.z
+        );
     }
 }

--- a/Assets/Scenes/TrainTaskV1/Scripts/Room.cs
+++ b/Assets/Scenes/TrainTaskV1/Scripts/Room.cs
@@ -460,6 +460,17 @@ public class Room : MonoBehaviour
                 DataCaptureSystem.Instance.ReportEvent("deceleration", true);
             }
         }
+
+        // Log clicks
+        if (Input.GetMouseButton(0) || Input.touchCount > 0)
+        {
+            Vector2 ClickPosition =
+                Input.touchCount > 0 ? Input.GetTouch(0).position : (Vector2)Input.mousePosition;
+            Vector3 ClickWorldPosition = Camera.main.ScreenToWorldPoint(ClickPosition);
+            DataCaptureSystem.Instance.ReportEvent("Click.x", ClickWorldPosition.x);
+            DataCaptureSystem.Instance.ReportEvent("Click.y", ClickWorldPosition.y);
+            DataCaptureSystem.Instance.ReportEvent("Click.z", ClickWorldPosition.z);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
This PR adds touch position and movable position (currently only Trains) to the logging files.  It also adds logging for every frame on which a train is present, rather than omitting all-false frames. 

Note: more than one touch event is not supported; only the first touch in the list is used